### PR TITLE
Created a new SymbolDecl type

### DIFF
--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -482,35 +482,35 @@ impl Symbol {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Never {
+pub struct NeverKeyword {
     pub val: Lexeme,
 }
 
-impl Never {
+impl NeverKeyword {
     pub fn new(val: Lexeme) -> Self {
-        Never { val }
+        NeverKeyword { val }
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct SelfValue {
+pub struct SelfKeyword {
     pub val: Lexeme,
 }
 
-impl SelfValue {
+impl SelfKeyword {
     pub fn new(val: Lexeme) -> Self {
-        SelfValue { val }
+        SelfKeyword { val }
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct UndefinedValue {
+pub struct UndefinedKeyword {
     pub val: Lexeme,
 }
 
-impl UndefinedValue {
+impl UndefinedKeyword {
     pub fn new(val: Lexeme) -> Self {
-        UndefinedValue { val }
+        UndefinedKeyword { val }
     }
 }
 
@@ -628,12 +628,14 @@ pub enum Expr {
     CharsValue(CharsValue),
     ArrayType(ArrayType),
     ValueType(ValueType),
+    FuncType(FuncType),
     ArgDef(ArgDef),
     BoolValue(BoolValue),
     Symbol(Symbol),
+    SymbolDecl(Symbol),
     AnonFuncDecl(AnonFuncDecl),
     FuncDecl(FuncDecl),
-    FuncType(FuncType),
+    SelfDecl(SelfKeyword),
     TraitDecl(TraitDecl),
     StructDecl(StructDecl),
     ErrorDecl(ErrorDecl),
@@ -642,9 +644,9 @@ pub enum Expr {
     TopDecl(TopDecl),
     Reassignment(Reassignment),
     Import(Import),
-    UndefinedValue(UndefinedValue),
-    SelfValue(SelfValue),
-    Never(Never),
+    UndefinedValue(UndefinedKeyword),
+    SelfValue(SelfKeyword),
+    Never(NeverKeyword),
     ArrayAccess(ArrayAccess),
     PropAccess(PropAccess),
     Invoke(Invoke),
@@ -659,9 +661,10 @@ impl Expr {
             _ => panic!("issue no symbol found"),
         }
     }
-    pub fn into_self_val(&self) -> SelfValue {
+    pub fn into_self(&self) -> SelfKeyword {
         match self {
             Expr::SelfValue(x) => x.to_owned(),
+            Expr::SelfDecl(x) => x.to_owned(),
             _ => panic!("issue no self keyword found"),
         }
     }
@@ -674,6 +677,7 @@ impl Expr {
     pub fn into_symbol(&self) -> Symbol {
         match self {
             Expr::Symbol(x) => x.to_owned(),
+            Expr::SymbolDecl(x) => x.to_owned(),
             _ => panic!("issue no symbol found {:?}", self),
         }
     }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -58,4 +58,5 @@ fn main() {
         println!("  [fail]\n issues: {:?}\n", linter.issues);
         std::process::exit(1);
     }
+    println!("  [ok] full lint success!");
 }

--- a/test/test.ty
+++ b/test/test.ty
@@ -16,7 +16,6 @@ const Day = tag
   | saturday
   | sunday
 
-
 const next_weekday = fn(d: Day) Day {
  // tags can be matched on
  // return must be specified
@@ -31,7 +30,7 @@ const next_weekday = fn(d: Day) Day {
 }
 
 // functions are defined in the previous example, to give the lambda syntax for free
-const c = [0,1,2,3].map(fn(x) usize { return x + 2 })
+const c = [0,1,2,3].map(fn(x: usize) usize { return x + 2 })
 
 // errors are first class citizens where control flow is designed to work well with errors.
 type InvalidWeekday = error {}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -198,6 +198,7 @@ pub enum TypeTree {
     // data types
     ArgInit(NoOp),
     SelfInit(NoOp),
+    SymbolInit(SymbolAccess),
     StructInit(StructInitialize),
     PropInit(Initialization),
     ArrayInit(ArrayInitialize),
@@ -297,6 +298,7 @@ impl TypeTree {
             TypeTree::UnknownValue => Ty::Unknown,
             TypeTree::ArgInit(x) => x.curried.clone(),
             TypeTree::SelfInit(x) => x.curried.clone(),
+            TypeTree::SymbolInit(x) => x.curried.clone(),
         }
     }
     pub fn into_declarator(&self) -> &DeclaratorInfo {
@@ -395,6 +397,7 @@ impl TypeTree {
             TypeTree::UnknownValue => "unknown value",
             TypeTree::ArgInit(_) => "function argument",
             TypeTree::SelfInit(_) => "self as function argument",
+            TypeTree::SymbolInit(_) => "symbol definition or initialization",
         }
     }
 }


### PR DESCRIPTION
This is working a lot better than refactoring all enums to be more specific instead of more nested Expr's

Long term, each union should be more succinct and varied, but this is a tedious problem in rust.

This specific change will allow the separation between symbol declarations and symbol access