### PR TITLE
Scopes Being Introduced

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ members = [
   "linter", 
   "codelocation",
   "types", 
-  "cachectx", "typetable"]
+  "cachectx", 
+  "typetable", 
+  "scopetable"
+]
 resolver = "2"
 

--- a/cachectx/Cargo.toml
+++ b/cachectx/Cargo.toml
@@ -11,6 +11,7 @@ parser = { path = "../parser" }
 ast = { path = "../ast" }
 symtable = { path = "../symtable" }
 typetable = { path = "../typetable" }
+scopetable = { path = "../scopetable" }
 types = { path = "../types" }
 linter = { path = "../linter" }
 ir = { path = "../ir" }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -49,8 +49,9 @@ fn main() {
         }
     }
     println!("[run] full linting without cache context");
-    let mut typ_table = TypeTable::new();
-    let mut linter = LintSource::new(&contents, &mut typ_table);
+    let mut ttbls = vec![];
+    let mut scopes = vec![];
+    let mut linter = LintSource::new(&contents, &mut scopes, &mut ttbls);
     let borrow = res.unwrap();
     let result = linter.lint_check(&mut borrow.to_owned());
 

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -263,10 +263,11 @@ mod tests {
             ),
             None,
         );
-        let mut type_table = TypeTable::new();
-        let mut linter = LintSource::new("test", &mut type_table);
+        let mut tt = vec![];
+        let mut scp = vec![];
+        let mut linter = LintSource::new("test", &mut scp, &mut tt);
         let linter_result = linter.check_func_decl(&func_def).unwrap();
-        let mut fir = IRSource::new(0, SymTable::new(), &linter.ttbl);
+        let mut fir = IRSource::new(0, SymTable::new(), &linter.ttbls.get(0).unwrap());
         let result = fir.begin(linter_result.0);
         /*
          * function u0:0() -> i64 system_v

--- a/linter/Cargo.toml
+++ b/linter/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 ast = { path = "../ast" }
 types = { path = "../types" }
 typetable = { path = "../typetable" }
+scopetable = { path = "../scopetable" }
 parser = { path = "../parser" }
 token = { path = "../token" }
 lexer = { path = "../lexer" }

--- a/objmaker/Cargo.toml
+++ b/objmaker/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 ast = { path = "../ast" }
 symtable = { path = "../symtable" }
+scopetable = { path = "../scopetable" }
 typetable = { path = "../typetable" }
 lexer = { path = "../lexer" }
 linter = { path = "../linter" }

--- a/objmaker/src/lib.rs
+++ b/objmaker/src/lib.rs
@@ -18,10 +18,11 @@ pub fn from_buffer(contents: &str, path: &Path) -> () {
     let lex = TLexer::new(&contents);
     let mut parse = Parser::new(lex);
     let ast_parsed = parse.all().unwrap();
-    let mut type_table = TypeTable::new();
-    let mut linter = LintSource::new(path.to_str().unwrap(), &mut type_table);
+    let mut type_tables = vec![];
+    let mut scopes = vec![];
+    let mut linter = LintSource::new(path.to_str().unwrap(), &mut scopes, &mut type_tables);
     let lint_res = linter.lint_check(&ast_parsed);
-    let mut ir = IRSource::new(0, SymTable::new(), linter.ttbl);
+    let mut ir = IRSource::new(0, SymTable::new(), linter.ttbls.get(0).unwrap());
     if linter.issues.len() > 0 {
         for x in linter.issues {
             println!("{}", x);
@@ -51,10 +52,11 @@ pub fn from_file(input_path: &PathBuf) -> () {
     let lex = TLexer::new(&contents);
     let mut parse = Parser::new(lex);
     let ast_parsed = parse.all().unwrap();
-    let mut type_table = TypeTable::new();
-    let mut linter = LintSource::new(input_path.to_str().unwrap(), &mut type_table);
+    let mut type_tables = vec![];
+    let mut scopes = vec![];
+    let mut linter = LintSource::new(input_path.to_str().unwrap(), &mut scopes, &mut type_tables);
     let lint_res = linter.lint_check(&ast_parsed);
-    let mut ir = IRSource::new(0, SymTable::new(), linter.ttbl);
+    let mut ir = IRSource::new(0, SymTable::new(), linter.ttbls.get(0).unwrap());
     if linter.issues.len() > 0 {
         panic!("linter issues exist");
     }

--- a/scopetable/Cargo.toml
+++ b/scopetable/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "scopetable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+typetable = { path = "../typetable" }
+types = { path = "../types" }

--- a/scopetable/src/lib.rs
+++ b/scopetable/src/lib.rs
@@ -1,0 +1,36 @@
+use std::rc::Rc;
+use types::*;
+use typetable::TypeTable;
+
+pub struct ScopeTable {
+    pub parent_scope: usize,
+    pub self_scope: usize,
+}
+
+impl ScopeTable {
+    pub fn new(parent_scope_id: usize, self_scope: usize) -> Self {
+        ScopeTable {
+            parent_scope: parent_scope_id,
+            self_scope,
+        }
+    }
+    pub fn get_tt_same_up<'sco, 'ttb: 'sco>(
+        &'sco self,
+        symbol: String,
+        ttbls: &'ttb Vec<TypeTable>,
+    ) -> Option<&Rc<Box<TypeTree>>> {
+        let tbl = ttbls.get(self.self_scope).unwrap();
+        let sibling = tbl.table.get(&symbol);
+        if sibling.is_some() {
+            return sibling;
+        }
+        if self.parent_scope != self.self_scope {
+            let ptbl = ttbls.get(self.parent_scope).unwrap();
+            let parent = ptbl.table.get(&symbol);
+            if parent.is_some() {
+                return parent;
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
scopes are needed as a precurser to data layout.
they also will allow for reduced symbol collision and when added at linter

scopes and type tables have been added and passed into linter. no usage yet other than the first typetable and setting the first top level scope